### PR TITLE
Allow training on larger datasets

### DIFF
--- a/src/layers.jl
+++ b/src/layers.jl
@@ -69,6 +69,11 @@ end
 end
 @nograd issymmetric
 
+@adjoint function softplus(x::Real)
+  y = softplus(x)
+  return y, Δ -> (Δ * σ(x),)
+end
+
 """
 Custom mean pooling layer that outputs a fixed-length feature vector irrespective of input dimensions, for consistent handling of different-sized graphs feeding to fully-connected dense layers afterwards. Adapted from Flux MeanPool.
 


### PR DESCRIPTION
So this was a bit unexpected, but it seems to be related to machine precision, since it was very difficult to get the model to fail even with the worst case scenario in many cases. The background is that the current definition of `softplus` lead to some ill-behaved gradients for large negative values.

```julia
julia> gradient(log ∘ exp, -100)
(0.9999999999999999,)
julia> gradient(log ∘ exp, -100 + eps(Float32))
(Inf32,)
```
 Which eventually manifested like so:
```julia
julia> gradient(x -> sum(softplus.(x)), randn(Float32, 3,3) .* 10f1 )
(Float32[NaN NaN 1.0; NaN 0.0014634054 NaN; NaN 1.7532707f-27 1.0],)
```

There is a PR on upstream to fix this, but I am adding the adjoint here so we don't have to worry about the dependencies too much for the time being. Defining the `adjoint` for `softplus` fixes this.

cc @rkurchin