### PR TITLE
docs: make.jl: minor fix - update "Edit on GitHub" redirect

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,6 +29,7 @@ makedocs(
         # Use clean URLs, unless built as a "local" build
         prettyurls = !("local" in ARGS),
         canonical = "https://aced-differentiate.github.io/AtomicGraphNets.jl/stable/",
+        edit_link = "main",
     ),
     linkcheck = "linkcheck" in ARGS,
 )


### PR DESCRIPTION
The "Edit on GitHub" button by default points to the `master` branch.
Make it directly point to the `main` branch instead.

Note: Only a minor cleanup fix since GitHub redirects to the default
branch if specified branch doesn't exist.

Signed-off-by: Anant Thazhemadam <anant.thazhemadam@gmail.com>